### PR TITLE
[6.3.x] [BZ-1274312] exclude jboss-logging-spi as it collides with jboss-logging

### DIFF
--- a/jbpm-dashboard-modules/jbpm-dashboard-webapp/pom.xml
+++ b/jbpm-dashboard-modules/jbpm-dashboard-webapp/pom.xml
@@ -57,6 +57,12 @@
       <dependency>
         <groupId>org.jboss.ironjacamar</groupId>
         <artifactId>ironjacamar-core-api</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-spi</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
 


### PR DESCRIPTION
 * there are classes with same FQN in both jars, jboss-logging-spi
   is not needed so it was removed from the assemblies