### PR TITLE
RHBPMS-4537: dashbuilder issue "integer = character varying"

### DIFF
--- a/jbpm-dashboard-modules/jbpm-dashboard-webapp/src/main/webapp/WEB-INF/deployments/jbpmKPIs_v2.kpis
+++ b/jbpm-dashboard-modules/jbpm-dashboard-webapp/src/main/webapp/WEB-INF/deployments/jbpmKPIs_v2.kpis
@@ -427,7 +427,7 @@
     <description language="en">jBPM Task Instances</description>
     <sqlprovider>
       <datasource>local</datasource>
-      <query>select ts.taskname, count(ts.taskid) taskid from BAMTaskSummary ts left join ProcessInstanceLog ps on (ts.processinstanceid=ps.processinstanceid) where {sql_condition, optional, ps.processname, processname} and {sql_condition, optional, ps.status, status} and {sql_condition, optional, ps.start_date, start_date} and {sql_condition, optional, ps.end_date, end_date} and {sql_condition, optional, ps.processversion, processversion} and {sql_condition, optional, ts.userid, userid} and {sql_condition, optional, ts.taskname, taskname} and {sql_condition, optional, ts.createddate, createddate} and {sql_condition, optional, ts.enddate, enddate} and {sql_condition, optional, ts.status, status} group by ts.taskname</query>
+      <query>select ts.taskname, count(ts.taskid) taskid from BAMTaskSummary ts left join ProcessInstanceLog ps on (ts.processinstanceid=ps.processinstanceid) where {sql_condition, optional, ps.processname, processname} and {sql_condition, optional, ps.status, status} and {sql_condition, optional, ps.start_date, start_date} and {sql_condition, optional, ps.end_date, end_date} and {sql_condition, optional, ps.processversion, processversion} and {sql_condition, optional, ts.userid, userid} and {sql_condition, optional, ts.taskname, taskname} and {sql_condition, optional, ts.createddate, createddate} and {sql_condition, optional, ts.enddate, enddate} and {sql_condition, optional, ts.status, taskstatus} group by ts.taskname</query>
     </sqlprovider>
     <dataproperties>
       <dataproperty id="taskname">


### PR DESCRIPTION
This fix depends on https://github.com/droolsjbpm/dashboard-builder/pull/103

IMPORTANT NOTE (ONLY FOR EXISTING INSTALLATIONS):  the data provider "jBPM Task Instances" must be modified manually by an administrator user through the dashbuilder UI as follows:

1.- Goto "Showcase>Administration>Data providers"
2.- Edit the "jBPM Task Instances" SQL
3.- At the end of the SQL, change "status" by "taskstatus" so that the condition looks like the following => {sql_condition, optional, ts.status, taskstatus}
4.- Save the changes.

